### PR TITLE
Adding ${SDL2_SOURCE_DIR}/include as a public include directory to th…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1592,6 +1592,7 @@ if(SDL_SHARED)
   endif()
   set(_INSTALL_LIBS "SDL2" ${_INSTALL_LIBS})
   target_link_libraries(SDL2 ${EXTRA_LIBS} ${EXTRA_LDFLAGS})
+  target_include_directories(SDL2 PUBLIC $<BUILD_INTERFACE:${SDL2_SOURCE_DIR}/include>)
 endif()
 
 if(SDL_STATIC)
@@ -1608,6 +1609,7 @@ if(SDL_STATIC)
   # libraries - do we need to consider this?
   set(_INSTALL_LIBS "SDL2-static" ${_INSTALL_LIBS})
   target_link_libraries(SDL2-static ${EXTRA_LIBS} ${EXTRA_LDFLAGS})
+  target_include_directories(SDL2-static PUBLIC $<BUILD_INTERFACE:${SDL2_SOURCE_DIR}/include>)
 endif()
 
 ##### Installation targets #####


### PR DESCRIPTION
…e SDL2 and SDL2-static targets, so that any consumer of these targets gets access to the header files (so he can do #include <SDL.h>)