### PR TITLE
gitignore xcuserdata

### DIFF
--- a/Xcode/.gitignore
+++ b/Xcode/.gitignore
@@ -1,0 +1,1 @@
+xcuserdata/


### PR DESCRIPTION
This prevents having things dirty in git when working with xcode
```
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	Xcode/SDL/SDL.xcodeproj/xcuserdata/
```


I know that this repo is only a mirror and code changes should land in the official repo. But because this mirror is a git repo and `.gitignore` is git specific.. maybe this improvement can go in.

@spurious  @okuoku