### PR TITLE
Fix the potential memcpy to itself, in case SDL_numGestureTouches is zero

### DIFF
--- a/src/events/SDL_gesture.c
+++ b/src/events/SDL_gesture.c
@@ -487,7 +487,9 @@ int SDL_GestureDelTouch(SDL_TouchID touchId)
     SDL_zero(SDL_gestureTouch[i]);
 
     SDL_numGestureTouches--;
-    SDL_memcpy(&SDL_gestureTouch[i], &SDL_gestureTouch[SDL_numGestureTouches], sizeof(SDL_gestureTouch[i]));
+    if (SDL_numGestureTouches > 0) {
+        SDL_memcpy(&SDL_gestureTouch[i], &SDL_gestureTouch[SDL_numGestureTouches], sizeof(SDL_gestureTouch[i]));
+    }
     return 0;
 }
 


### PR DESCRIPTION
==389919== Thread 1:
==389919== Source and destination overlap in memcpy(0x732abf0, 0x732abf0, 8240)
==389919==    at 0x4C32513: memcpy@@GLIBC_2.14 (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==389919==    by 0x460C2C: SDL_memcpy_REAL (SDL_string.c:321)
==389919==    by 0x440132: SDL_GestureDelTouch (SDL_gesture.c:490)
==389919==    by 0x444EE7: SDL_DelTouch (SDL_touch.c:460)
==389919==    by 0x444F21: SDL_TouchQuit (SDL_touch.c:469)
==389919==    by 0x477761: SDL_VideoQuit_REAL (SDL_video.c:2955)
==389919==    by 0x58581D: SDL_QuitSubSystem_REAL (SDL.c:370)
==389919==    by 0x5859C6: SDL_Quit_REAL (SDL.c:435)
==389919==    by 0x432973: SDL_Quit (SDL_dynapi_procs.h:89)